### PR TITLE
fix: Re-raise deposit error outside of refund try block.

### DIFF
--- a/workflows.py
+++ b/workflows.py
@@ -53,10 +53,12 @@ class MoneyTransfer:
                 workflow.logger.info(
                     f"Refund successful. Confirmation ID: {refund_output}"
                 )
-                raise deposit_err
             except ActivityError as refund_error:
                 workflow.logger.error(f"Refund failed: {refund_error}")
-                raise refund_error
+                raise refund_error from deposit_err
+
+            # Re-raise deposit error if refund was successful
+            raise deposit_err
 
 
 # @@@SNIPEND


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Two changes:

- Where the deposit error is raised
- Showing the refund error being raised _from_ the deposit error

## Why?
<!-- Tell your future self why have you made these changes -->
Currently, the deposit error gets raised within the `try` block of the refund attempt such that even though we end up with a successful refund (you can confirm by viewing INFO level logs), we get a log message showing that the refund failed even though it didn't, it was just the deposit that failed.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
N/A
2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
* Tested manually by running the deposit activity calling `self.bank.deposit_that_fails` and observing that we no longer get a  log message showing `Refund failed...`
* Existing unit tests still pass

3. Any docs updates needed?
N/A
