### PR TITLE
EDU-3801: Update Money Transfer tutorial code to support Temporal Cloud

### DIFF
--- a/client_provider.py
+++ b/client_provider.py
@@ -1,0 +1,36 @@
+import os
+from temporalio.client import Client, TLSConfig
+
+async def get_temporal_client() -> Client:
+    cert_path = os.getenv("TEMPORAL_TLS_CERT")
+    key_path = os.getenv("TEMPORAL_TLS_KEY")
+    api_key = os.getenv("TEMPORAL_API_KEY")
+
+    # Check for mTLS authentication
+    if cert_path and key_path:
+        with open(cert_path, "rb") as f:
+            client_cert = f.read()
+        with open(key_path, "rb") as f:
+            client_key = f.read()
+
+        return await Client.connect(
+            os.getenv("TEMPORAL_ADDRESS"),
+            namespace=os.getenv("TEMPORAL_NAMESPACE"),
+            tls=TLSConfig(
+                client_cert=client_cert,
+                client_private_key=client_key,
+            ),
+        )
+    elif api_key:
+        return await Client.connect(
+            os.getenv("TEMPORAL_ADDRESS"),
+            namespace=os.getenv("TEMPORAL_NAMESPACE"),
+            api_key=api_key,
+            tls=True,
+        )
+
+    else:
+        return await Client.connect(
+            os.getenv("TEMPORAL_ADDRESS", "localhost:7233"),
+            namespace=os.getenv("TEMPORAL_NAMESPACE", "default"),
+        )

--- a/run_worker.py
+++ b/run_worker.py
@@ -11,7 +11,6 @@ from workflows import MoneyTransfer
 
 
 async def main() -> None:
-    #client: Client = await Client.connect("localhost:7233", namespace="default")
     client = await get_temporal_client()
     # Run the worker
     activities = BankingActivities()

--- a/run_worker.py
+++ b/run_worker.py
@@ -4,13 +4,15 @@ import asyncio
 from temporalio.client import Client
 from temporalio.worker import Worker
 
+from client_provider import get_temporal_client
 from activities import BankingActivities
 from shared import MONEY_TRANSFER_TASK_QUEUE_NAME
 from workflows import MoneyTransfer
 
 
 async def main() -> None:
-    client: Client = await Client.connect("localhost:7233", namespace="default")
+    #client: Client = await Client.connect("localhost:7233", namespace="default")
+    client = await get_temporal_client()
     # Run the worker
     activities = BankingActivities()
     worker: Worker = Worker(

--- a/run_workflow.py
+++ b/run_workflow.py
@@ -4,13 +4,13 @@ import traceback
 
 from temporalio.client import Client, WorkflowFailureError
 
+from client_provider import get_temporal_client
 from shared import MONEY_TRANSFER_TASK_QUEUE_NAME, PaymentDetails
 from workflows import MoneyTransfer
 
 
 async def main() -> None:
-    # Create client connected to server at the given address
-    client: Client = await Client.connect("localhost:7233")
+    client = await get_temporal_client()
 
     data: PaymentDetails = PaymentDetails(
         source_account="85-150",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

DO NOT MERGE.

I have created this draft PR to support review and sharing this code. However, I do not intend for this code to become part of the `main` branch, as it is my hope that what's on this branch will become obsolete when the SDKs support environment-based configuration.

## What was changed
I added code to configure Temporal Client options based on the presence of environment variables. I also updated the Clients created by the Worker and Starter code to use it.


## Why?
<!-- Tell your future self why have you made these changes -->
Currently, the clients used in this tutorial have no explicit configuration and rely solely on the default options. Imagine that someone new to Temporal application development signed up for Temporal Cloud on their own and now wants to run this intro-level money transfer tutorial. Getting it to work with Temporal Cloud requires making changes to the Client configuration, but this user won't know what to change. Note that this scenario I've described isn't limited to Temporal Cloud. Someone using a non-default Namespace name or a non-local Temporal Service would have the same problem.

Having the clients configure themselves based on the presence of environment variables eliminates the need to hardcode the frontend address, Namespace name, or authentication details. It helps the user understand that the application logic remains unchanged when migrating from the Temporal Service used for development on their laptop to a production Temporal Service (or vice versa). Finally, this makes it easier for users to run this example locally, on a remote self-hosted cluster, or on Temporal Cloud. Unfortunately, the SDKs do not support this yet (although it has been [discussed](https://github.com/temporalio/features/issues/441)), so this has to be done within the application itself in the interim. 

NOTE: I have updated the code but not the prose in the tutorial, pending further discussion with the Education team. I plan to make similar changes to the other money-transfer repos, but if it turns out that is not viable, then I will probably need to fork these repos and tutorials to support the onboarding path for new cloud users.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

This does not close an issue, but enables further progress of EDU-3801. That issue would be closed only after all similar tutorials have been updated. 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I tested this in three scenarios:

### Local Temporal Service (started via CLI) using the `default` namespace. 
In this scenario, I set no environment variables. I ran the Worker and Starter code and the Workflow ran to completion. 


### Temporal Cloud, using mTLS 
In this scenario,  I set the four environment variables below (note that these values are similar to but not identical to the ones I actually set):

```bash
export TEMPORAL_ADDRESS='example.c9ef8.tmprl.cloud:7233'
export TEMPORAL_NAMESPACE='example.c9ef8'
export TEMPORAL_TLS_CERT='mycert.pem'
export TEMPORAL_TLS_KEY='mykey.key'
```

To verify that mTLS was used for authentication, I disabled API Keys for authentication on the Namespace in this scenario. I then ran the Worker and Starter code and the Workflow ran to completion. 

### Temporal Cloud, using API Keys 
In this scenario,  I set the three environment variables below (note that these values are similar to but not identical to the ones I actually set):

```bash
export TEMPORAL_ADDRESS='us-east-1.aws.api.temporal.io'
export TEMPORAL_NAMESPACE='example.c9ef8'
export TEMPORAL_API_KEY='abc123.actual.value.redacted.xyz789' 
```

To verify that the API keys were used for authentication, I disabled mTLS authentication on the Namespace in this scenario. I then ran the Worker and Starter code and the Workflow ran to completion. 


3. Any docs updates needed?

The tutorial prose will require a small update to describe the changes and explain which environment variables one must set for non-default scenarios.