### PR TITLE
Config client from profile

### DIFF
--- a/client_provider.py
+++ b/client_provider.py
@@ -1,0 +1,36 @@
+import os
+from temporalio.client import Client, TLSConfig
+
+async def get_temporal_client() -> Client:
+    cert_path = os.getenv("TEMPORAL_TLS_CERT")
+    key_path = os.getenv("TEMPORAL_TLS_KEY")
+    api_key = os.getenv("TEMPORAL_API_KEY")
+
+    # Check for mTLS authentication
+    if cert_path and key_path:
+        with open(cert_path, "rb") as f:
+            client_cert = f.read()
+        with open(key_path, "rb") as f:
+            client_key = f.read()
+
+        return await Client.connect(
+            os.getenv("TEMPORAL_ADDRESS"),
+            namespace=os.getenv("TEMPORAL_NAMESPACE"),
+            tls=TLSConfig(
+                client_cert=client_cert,
+                client_private_key=client_key,
+            ),
+        )
+    elif api_key:
+        return await Client.connect(
+            os.getenv("TEMPORAL_ADDRESS"),
+            namespace=os.getenv("TEMPORAL_NAMESPACE"),
+            api_key=api_key,
+            tls=True,
+        )
+
+    else:
+        return await Client.connect(
+            os.getenv("TEMPORAL_ADDRESS", "localhost:7233"),
+            namespace=os.getenv("TEMPORAL_NAMESPACE", "default"),
+        )

--- a/client_provider.py
+++ b/client_provider.py
@@ -1,16 +1,20 @@
 import os
+import pathlib
+import platform
 from temporalio.client import Client, TLSConfig
 from temporalio.envconfig import ClientConfig
 
 
+# Configures and returns a Temporal Client. This uses the default
+# settings, unless the TEMPORAL_PROFILE environment variable is set,
+# in which case it configures it as per the specified profile name.
 async def get_temporal_client() -> Client:
-    config_file_path = os.getenv("TEMPORAL_CONFIG_PATH")
-    profile_name = os.getenv("TEMPORAL_PROFILE_NAME")
-    if config_file_path and profile_name:
-        # DO PROFILE THING
+    config_file_path = get_config_file_path()
+    profile_name = os.getenv("TEMPORAL_PROFILE")
+    if profile_name and config_file_path.is_file():
         connect_config = ClientConfig.load_client_connect_config(
             profile=profile_name,
-            config_file=config_file_path,
+            config_file=str(config_file_path),
         )
         return await Client.connect(**connect_config)
     else:
@@ -18,3 +22,28 @@ async def get_temporal_client() -> Client:
             os.getenv("TEMPORAL_ADDRESS", "localhost:7233"),
             namespace=os.getenv("TEMPORAL_NAMESPACE", "default"),
         )
+
+
+# Returns the path representing the default location of the
+# configuration file, based on the current operating system.
+def get_config_file_path() -> pathlib.Path:
+    home = pathlib.Path.home()
+    system = platform.system()
+
+    if system == "Darwin":
+        config_file_path = home / "Library/Application Support/temporalio/temporal.toml"
+    elif system == "Windows":
+        app_data = os.getenv("AppData")
+        if app_data is None:
+            raise RuntimeError("AppData environment variable not set")
+        config_file_path = pathlib.Path(app_data) / "temporalio/temporal.toml"
+    else:
+        xdg_config_home = os.getenv("XDG_CONFIG_HOME")
+        if xdg_config_home:
+            config_file_path = (
+                pathlib.Path(xdg_config_home) / "temporalio/temporal.toml"
+            )
+        else:
+            config_file_path = home / ".config/temporalio/temporal.toml"
+
+    return config_file_path

--- a/client_provider.py
+++ b/client_provider.py
@@ -1,34 +1,18 @@
 import os
 from temporalio.client import Client, TLSConfig
+from temporalio.envconfig import ClientConfig
+
 
 async def get_temporal_client() -> Client:
-    cert_path = os.getenv("TEMPORAL_TLS_CERT")
-    key_path = os.getenv("TEMPORAL_TLS_KEY")
-    api_key = os.getenv("TEMPORAL_API_KEY")
-
-    # Check for mTLS authentication
-    if cert_path and key_path:
-        with open(cert_path, "rb") as f:
-            client_cert = f.read()
-        with open(key_path, "rb") as f:
-            client_key = f.read()
-
-        return await Client.connect(
-            os.getenv("TEMPORAL_ADDRESS"),
-            namespace=os.getenv("TEMPORAL_NAMESPACE"),
-            tls=TLSConfig(
-                client_cert=client_cert,
-                client_private_key=client_key,
-            ),
+    config_file_path = os.getenv("TEMPORAL_CONFIG_PATH")
+    profile_name = os.getenv("TEMPORAL_PROFILE_NAME")
+    if config_file_path and profile_name:
+        # DO PROFILE THING
+        connect_config = ClientConfig.load_client_connect_config(
+            profile=profile_name,
+            config_file=config_file_path,
         )
-    elif api_key:
-        return await Client.connect(
-            os.getenv("TEMPORAL_ADDRESS"),
-            namespace=os.getenv("TEMPORAL_NAMESPACE"),
-            api_key=api_key,
-            tls=True,
-        )
-
+        return await Client.connect(**connect_config)
     else:
         return await Client.connect(
             os.getenv("TEMPORAL_ADDRESS", "localhost:7233"),

--- a/run_worker.py
+++ b/run_worker.py
@@ -11,7 +11,6 @@ from workflows import MoneyTransfer
 
 
 async def main() -> None:
-    #client: Client = await Client.connect("localhost:7233", namespace="default")
     client = await get_temporal_client()
     # Run the worker
     activities = BankingActivities()

--- a/run_worker.py
+++ b/run_worker.py
@@ -4,13 +4,15 @@ import asyncio
 from temporalio.client import Client
 from temporalio.worker import Worker
 
+from client_provider import get_temporal_client
 from activities import BankingActivities
 from shared import MONEY_TRANSFER_TASK_QUEUE_NAME
 from workflows import MoneyTransfer
 
 
 async def main() -> None:
-    client: Client = await Client.connect("localhost:7233", namespace="default")
+    #client: Client = await Client.connect("localhost:7233", namespace="default")
+    client = await get_temporal_client()
     # Run the worker
     activities = BankingActivities()
     worker: Worker = Worker(

--- a/run_workflow.py
+++ b/run_workflow.py
@@ -4,13 +4,13 @@ import traceback
 
 from temporalio.client import Client, WorkflowFailureError
 
+from client_provider import get_temporal_client
 from shared import MONEY_TRANSFER_TASK_QUEUE_NAME, PaymentDetails
 from workflows import MoneyTransfer
 
 
 async def main() -> None:
-    # Create client connected to server at the given address
-    client: Client = await Client.connect("localhost:7233")
+    client = await get_temporal_client()
 
     data: PaymentDetails = PaymentDetails(
         source_account="85-150",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->
DO NOT MERGE.

I have created this draft PR to support review and sharing this code. However, I do not intend for this code to become part of the `main` branch right now.

## What was changed
I added code to configure the Temporal Client from a configuration file that defines a named profile, which specifies the frontend address of the Temporal Service, the Namespace, and details related to the desired authentication method. It uses the default location of the configuration file, but the profile name to use within it is specified through an environment variable. The Worker and Starter code use the Client returned by this code.


## Why?
<!-- Tell your future self why have you made these changes -->
Currently, the clients used in this tutorial have no explicit configuration and rely solely on the default options. Imagine that someone new to Temporal application development signed up for Temporal Cloud on their own and now wants to run this intro-level money transfer tutorial. Getting it to work with Temporal Cloud requires making changes to the Client configuration, but this user won't know what to change. Note that this scenario I've described isn't limited to Temporal Cloud. Someone using a non-default Namespace name or a non-local Temporal Service would have the same problem.

Having the clients configure themselves based on the presence of environment variables eliminates the need to hardcode the frontend address, Namespace name, or authentication details. It helps the user understand that the application logic remains unchanged when migrating from the Temporal Service used for development on their laptop to a production Temporal Service (or vice versa). Finally, this makes it easier for users to run this example locally, on a remote self-hosted cluster, or on Temporal Cloud. 

This updated takes advantage of the pre-release support for profile-based configuration in the Python SDK.

NOTE: I have updated the code but not the prose in the tutorial, pending further discussion with the Education team. I plan to make similar changes to the other money-transfer repos, but if it turns out that is not viable, then I will probably need to fork these repos and tutorials to support the onboarding path for new cloud users.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

This does not close an issue, but enables further progress of EDU-3801. That issue would be closed only after all similar tutorials have been updated. 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

I tested this by first creating a profile named `cloud` using the Temporal CLI (note that these values are similar to but not identical to the ones I actually set):

```
$ temporal --profile cloud config set --prop address --value "us-east-1.aws.api.temporal.io:7233"
$ temporal --profile cloud config set --prop namespace --value "example.c9ef8"
$ temporal --profile cloud config set --prop api_key --value "abc123.actual.value.redacted.xyz789"
```

According to the output from this command, the config file was created at `$HOME/Library/Application Support/temporalio/temporal.toml`.

I then set an environment variable:

```
export TEMPORAL_PROFILE=cloud
```

I started the Worker, opened a new terminal tab and set the same environment variables above, and started the Workflow. I verified in the Temporal Cloud Web UI that the Workflow Execution ran and completed successfully.

3. Any docs updates needed?

The tutorial prose will require a small update to describe the changes and explain which environment variable one must set for non-default scenarios.