### PR TITLE
An earlier change removed the commented out code which is critical fo…

### DIFF
--- a/activities.py
+++ b/activities.py
@@ -42,6 +42,8 @@ class BankingActivities:
                 reference_id,
             )
             """
+            
+            # confirmation = self.bank.deposit_that_fails(data.target_account, data.amount, reference_id)
             return confirmation
         except InvalidAccountError:
             raise

--- a/workflows.py
+++ b/workflows.py
@@ -15,7 +15,6 @@ class MoneyTransfer:
     @workflow.run
     async def run(self, payment_details: PaymentDetails) -> str:
         retry_policy = RetryPolicy(
-            maximum_attempts=3,
             maximum_interval=timedelta(seconds=2),
             non_retryable_error_types=["InvalidAccountError", "InsufficientFundsError"],
         )


### PR DESCRIPTION
## What was changed
The retry policy being specified in the source code ran counter to the intention of the tutorial. It resulted in problems when users were trying to follow the instructions. I removed the max retries to force it to retry forever instead. This allows the tutorial to proceed as expected. However this required updating the instructions which had conflicting information about the actual retry policy.

## Why?
While running through this tutorial I discovered that the way retries were set up ran counter to what the instructions seemed to be indicating and resulted in an application that failed rather then demonstrating the power of Temporal. Meanwhile, the instructions had conflicts claiming both that there was a maximum of 3 retries but also a maximum of 500. I've fixed these errors while adjusting the retry policy.

## Checklist
1. How was this tested:

I've run the application locally and updating the instructions to match.