### PR TITLE
Use envconfig for tutorial clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,18 @@ env\Scripts\activate
 With the virtual environment configured, install the Temporal SDK:
 
 ```
-python -m pip install temporalio
+python -m pip install "temporalio>=1.18.1"
 ```
+
+## Configure the Temporal Client
+
+By default, this template connects to a local Temporal server at
+`localhost:7233` in the `default` namespace. To connect elsewhere, configure
+the Temporal SDK with a `temporal.toml` profile or the supported environment
+variables. See the [SDK environment configuration API](https://python.temporal.io/temporalio.envconfig.ClientConfig.html) for available settings, including Temporal Cloud API keys.
+
+When `TEMPORAL_PROFILE` is unset, the SDK uses `profile.default` from the
+configuration file when present. An explicitly named profile must exist.
 
 
 Run the workflow:

--- a/client_provider.py
+++ b/client_provider.py
@@ -1,0 +1,9 @@
+from temporalio.client import Client
+from temporalio.envconfig import ClientConfig
+
+
+async def get_temporal_client() -> Client:
+    config = ClientConfig.load_client_connect_config()
+    config["target_host"] = config.get("target_host") or "localhost:7233"
+    config["namespace"] = config.get("namespace") or "default"
+    return await Client.connect(**config)

--- a/run_worker.py
+++ b/run_worker.py
@@ -1,16 +1,16 @@
 # @@@SNIPSTART python-money-transfer-project-template-run-worker
 import asyncio
 
-from temporalio.client import Client
 from temporalio.worker import Worker
 
 from activities import BankingActivities
+from client_provider import get_temporal_client
 from shared import MONEY_TRANSFER_TASK_QUEUE_NAME
 from workflows import MoneyTransfer
 
 
 async def main() -> None:
-    client: Client = await Client.connect("localhost:7233", namespace="default")
+    client = await get_temporal_client()
     # Run the worker
     activities = BankingActivities()
     worker: Worker = Worker(

--- a/run_workflow.py
+++ b/run_workflow.py
@@ -2,15 +2,15 @@
 import asyncio
 import traceback
 
-from temporalio.client import Client, WorkflowFailureError
+from temporalio.client import WorkflowFailureError
 
+from client_provider import get_temporal_client
 from shared import MONEY_TRANSFER_TASK_QUEUE_NAME, PaymentDetails
 from workflows import MoneyTransfer
 
 
 async def main() -> None:
-    # Create client connected to server at the given address
-    client: Client = await Client.connect("localhost:7233")
+    client = await get_temporal_client()
 
     data: PaymentDetails = PaymentDetails(
         source_account="85-150",


### PR DESCRIPTION
## What was changed

The worker and workflow starter now share one client factory that loads the Python SDK's standard environment configuration. It supports Temporal CLI profiles, custom config paths, and direct `TEMPORAL_*` overrides while explicitly retaining `localhost:7233` and the `default` Namespace when settings are absent.

The README documents the configuration API and requires an SDK version that provides it.

## Why?

Both entry points previously hard-coded local connection values, so the Cloud profile created during onboarding was ignored. The SDK now owns profile selection, environment precedence, API-key authentication, and TLS behavior; the template only supplies explicit local defaults when those values are unset.

This focused change supersedes #6 and #8.

## Checklist

1. Closes: N/A

2. How was this tested:
   - `python -m compileall -q .`
   - Manual empty-configuration loader smoke
   - Manual named-profile loader smoke targeting `localhost:17233`
   - Existing environment does not include `pytest`; no test files were changed

3. Any docs updates needed?
   - Updated the README with the supported SDK version, configuration API, and local defaults.
